### PR TITLE
Fix initialize in Ruby 2.1

### DIFF
--- a/lib/closeio/base.rb
+++ b/lib/closeio/base.rb
@@ -17,7 +17,7 @@ module Closeio
       if attrs['data']
         super attrs['data']
       else
-        super attrs
+        super Hash[attrs]
       end
     end
 


### PR DESCRIPTION
attrs needs to be cast to a Hash, or else it might break when OpenStruct gets a hold of it.
