### PR TITLE
Add railtie for setting the api key via configuration file

### DIFF
--- a/lib/closeio.rb
+++ b/lib/closeio.rb
@@ -19,3 +19,5 @@ require 'closeio/saved_search'
 require 'closeio/task'
 require 'closeio/user'
 require 'closeio/version'
+require 'closeio/config'
+require 'closeio/railtie' if defined?(Rails)

--- a/lib/closeio/config.rb
+++ b/lib/closeio/config.rb
@@ -1,0 +1,23 @@
+module Closeio
+  module Config
+
+    class << self
+      attr_accessor :config
+      attr_accessor :api_key
+    end
+
+    %w(api_key).each do |method_name|
+      define_singleton_method(method_name) do
+        @config.fetch(method_name)
+      end
+      define_singleton_method("#{method_name}=") do |value|
+        if @config.blank?
+          @config = {method_name => value}
+        else
+          @config[method_name] = value
+        end
+      end
+    end
+
+  end
+end

--- a/lib/closeio/railtie.rb
+++ b/lib/closeio/railtie.rb
@@ -1,0 +1,12 @@
+module Closeio
+  class Railtie < Rails::Railtie
+
+    initializer "setup closeio" do
+      config_file = Rails.root.join("config", "closeio.yml")
+      if config_file.file?
+        Closeio::Config.config = YAML.load(ERB.new(config_file.read).result)[Rails.env]
+        Closeio::Base.basic_auth Closeio::Config.api_key, ''
+      end
+    end
+  end
+end


### PR DESCRIPTION
When using this gem in a rails application it's a lot more easier to have a configuration file with the api key instead of the env variable. This commit adds both a configuration and a railtie.
