### PR TITLE
Allow query params to be passed as a hash when searching leads, to keep client API consistent. Add options param to #list_leads to allow usage of meta search fields, such as _limit, _fields, and _skip.

### DIFF
--- a/lib/closeio/resources/lead.rb
+++ b/lib/closeio/resources/lead.rb
@@ -2,9 +2,9 @@ module Closeio
   class Client
     module Lead
 
-      def list_leads(options = {}, paginate = false, fields = nil)
-        params = { query: options }
-        params.merge!( _fields: fields ) if fields
+      def list_leads(query = {}, paginate = false, fields = nil, options = {})
+        options[:_fields] = fields if fields
+        params = assemble_list_query query, options
 
         if paginate
           paginate(lead_path, params)
@@ -37,6 +37,16 @@ module Closeio
 
       def lead_path(id=nil)
         id ? "lead/#{id}/" : "lead/"
+      end
+
+      def assemble_list_query(query, options)
+        options[:query] = if query.respond_to? :map
+          query.map { |k,v| "#{k}:'#{v}'" }.join(' ')
+        else
+          query
+        end
+
+        options
       end
 
     end


### PR DESCRIPTION
Fixes #20 

Ideally, the `fields` param could be deprecated, as the `options` param is a functional replacement. Didn't want to break the current API, though...