### PR TITLE
Adding option to pass in SSL certificate file path for Faraday to work on Heroku

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,19 @@ Add this line to your application's Gemfile:
   smart_views.leads
 ````
 
+### Options
+
+You can disable the logger by passing in a second argument when creating a new client:
+```ruby
+  client = Closeio::Client.new("api key", false)
+```
+
+Some servers running on SSL need [specific configurations](https://github.com/lostisland/faraday/wiki/Setting-up-SSL-certificates) for the Faraday dependency.
+If you're running on Heroku with SSL enabled, you need to pass in the path of the CA certificate when creating a new client:
+```ruby
+  client = Closeio::Client.new("api key", true, '/usr/lib/ssl/certs/ca-certificates.crt')
+```
+
 ### History
 
 View the [changelog](https://github.com/taylorbrooks/closeio/blob/master/CHANGELOG.md)

--- a/lib/closeio/client.rb
+++ b/lib/closeio/client.rb
@@ -20,11 +20,12 @@ module Closeio
     include Closeio::Client::Task
     include Closeio::Client::User
 
-    attr_reader :api_key, :logger
+    attr_reader :api_key, :logger, :ca_file
 
-    def initialize(api_key, logger = true)
+    def initialize(api_key, logger = true, ca_file = nil)
       @api_key = api_key
       @logger  = logger
+      @ca_file  = ca_file
     end
 
     def get(path, options={})
@@ -65,7 +66,8 @@ module Closeio
 
 
     def connection
-      Faraday.new(url: "https://app.close.io/api/v1", headers: { accept: 'application/json' }) do |conn|
+      Faraday.new(url: "https://app.close.io/api/v1", headers: { accept: 'application/json' }, ssl: {
+    ca_file: ca_file}) do |conn|
         conn.basic_auth api_key, ''
         conn.request    :json
         conn.response   :logger if logger


### PR DESCRIPTION
This gem won't work on Heroku with SSL enabled unless the path of the CA certificate is passed on to Faraday.