### PR TITLE
remove query key from list opportunities

### DIFF
--- a/lib/closeio/resources/opportunity.rb
+++ b/lib/closeio/resources/opportunity.rb
@@ -3,7 +3,7 @@ module Closeio
     module Opportunity
 
       def list_opportunities(options={})
-        get(opportunity_path, query: options)
+        get(opportunity_path, options)
       end
 
       def find_opportunity(id)


### PR DESCRIPTION
Remove `query` param being added by default for `list_opportunities` endpoint

Proposed fix for https://github.com/taylorbrooks/closeio/issues/31