### PR TITLE
add list_users query

### DIFF
--- a/lib/closeio/resources/user.rb
+++ b/lib/closeio/resources/user.rb
@@ -2,6 +2,10 @@ module Closeio
   class Client
     module User
 
+      def list_users
+        get("user/")
+      end
+
       def find_user(id)
         get("user/#{id}/")
       end


### PR DESCRIPTION
Add ability to query the close.io `list_users` API endpoint

i.e. `GET /user/`

As per: https://developer.close.io/#users