### PR TITLE
Create error class for 429: Too Many Requests

### DIFF
--- a/lib/closeio/error.rb
+++ b/lib/closeio/error.rb
@@ -3,6 +3,7 @@ module Closeio
   class NotAuthorized < Error; end
   class NotFound < Error; end
   class GatewayTimeout < Error; end
+  class TooManyRequests < Error; end
 end
 
 require 'faraday'
@@ -15,6 +16,8 @@ module FaradayMiddleware
         raise Closeio::NotAuthorized, env.body
       when 404
         raise Closeio::NotFound, env.body
+      when 429
+        raise Closeio::TooManyRequests, env.body
       when 504
         raise Closeio::GatewayTimeout, env.body
       when ERROR_STATUSES


### PR DESCRIPTION
Simplify handling of rate limiting errors