### PR TITLE
Support Email Sequence Subscription manipulations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
+## 3.4.1
+
+- Add support for email sequence subscriptions
+
 ## 2.5.0
+
 - Add middleware for handling errors when Close.io responds with status codes between 400-599
 
 ## 2.4.0

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Fwiw, I also run [DripEmails.com](https://www.DripEmails.com) -- a service for b
 Add this line to your application's Gemfile:
 ````ruby
   # in your Gemfile
-  gem 'closeio', '~> 3.2'
+  gem 'closeio', '~> 3.4'
 
   # then...
   bundle install

--- a/lib/closeio/client.rb
+++ b/lib/closeio/client.rb
@@ -23,6 +23,7 @@ module Closeio
     include Closeio::Client::Report
     include Closeio::Client::Sequence
     include Closeio::Client::SequenceSchedule
+    include Closeio::Client::SequenceSubscription
     include Closeio::Client::SmartView
     include Closeio::Client::Task
     include Closeio::Client::User

--- a/lib/closeio/resources/sequence_subscription.rb
+++ b/lib/closeio/resources/sequence_subscription.rb
@@ -9,7 +9,7 @@ module Closeio
         get(sequence_subscription_path(id))
       end
 
-      def subscribe_contact(options = {})
+      def create_sequence_subscription(options = {})
         post(sequence_subscription_path, options)
       end
 

--- a/lib/closeio/resources/sequence_subscription.rb
+++ b/lib/closeio/resources/sequence_subscription.rb
@@ -1,0 +1,27 @@
+module Closeio
+  class Client
+    module SequenceSubscription
+      def list_sequence_subscriptions
+        get(sequence_subscription_path, {})
+      end
+
+      def find_sequence_subscription(id)
+        get(sequence_subscription_path(id))
+      end
+
+      def subscribe_contact(options = {})
+        post(sequence_subscription_path, options)
+      end
+
+      def update_sequence_subscription(id, options = {})
+        put(sequence_subscription_path(id), options)
+      end
+
+      private
+
+      def sequence_subscription_path(id = nil)
+        id ? "sequence_subscription/#{id}/" : 'sequence_subscription/'
+      end
+    end
+  end
+end

--- a/lib/closeio/resources/sequence_subscription.rb
+++ b/lib/closeio/resources/sequence_subscription.rb
@@ -1,8 +1,8 @@
 module Closeio
   class Client
     module SequenceSubscription
-      def list_sequence_subscriptions
-        get(sequence_subscription_path, {})
+      def list_sequence_subscriptions(options = {})
+        get(sequence_subscription_path, options)
       end
 
       def find_sequence_subscription(id)

--- a/lib/closeio/version.rb
+++ b/lib/closeio/version.rb
@@ -1,3 +1,3 @@
 module Closeio
-  VERSION = '3.4.0'.freeze
+  VERSION = '3.4.1'.freeze
 end


### PR DESCRIPTION
Adding the ability to **list**, **fetch**, **create** and **update** Email Sequence Subscriptions in accordance to [the docs](https://developer.close.io/#email-sequences-list-sequence-subscriptions).

I bumped the version from 3.4.0 to 3.4.1, not sure it's the right thing to do, let me know!