### PR TITLE
Change base url to api.close.com

### DIFF
--- a/lib/closeio/client.rb
+++ b/lib/closeio/client.rb
@@ -86,7 +86,7 @@ module Closeio
 
     def connection
       Faraday.new(
-        url: 'https://app.close.io/api/v1',
+        url: 'https://api.close.com/api/v1',
         headers: {
           accept: 'application/json',
           'User-Agent' => "closeio-ruby-gem/v#{Closeio::VERSION}",

--- a/lib/closeio/version.rb
+++ b/lib/closeio/version.rb
@@ -1,3 +1,3 @@
 module Closeio
-  VERSION = '3.5.0'.freeze
+  VERSION = '3.5.1'.freeze
 end


### PR DESCRIPTION
Hey Taylor -- As part of an ongoing restructuring, we're switching the base url of the Close API to api.close.com instead of app.close.io.

This PR makes that switch for your Ruby gem :) Let me know if anything else is needed here! 