### PR TITLE
Add Closeio::Client#find_call

### DIFF
--- a/lib/closeio/resources/activity.rb
+++ b/lib/closeio/resources/activity.rb
@@ -77,6 +77,10 @@ module Closeio
         get(call_path, options)
       end
 
+      def find_call(id)
+        get("#{call_path}#{id}/")
+      end
+
       def create_call(options = {})
         post(call_path, options)
       end


### PR DESCRIPTION
This PR adds a new method on the client to find calls by their ID.

Let me know what I should bump the version to!