### PR TITLE
Add support for SMS activities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.6.0
+
+- Add support for SMS activities
+
 ## 3.5.0
 
 - Add support for Webhook endpoint

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ I :heart: Close, so if you have problems using the gem or would like to see supp
 Add this line to your application's Gemfile:
 ````ruby
   # in your Gemfile
-  gem 'closeio', '~> 3.4'
+  gem 'closeio', '~> 3.6'
 
   # then...
   bundle install

--- a/lib/closeio/resources/activity.rb
+++ b/lib/closeio/resources/activity.rb
@@ -116,23 +116,23 @@ module Closeio
       end
 
       def note_path
-        'activity/note/'
+        "#{activity_path}note/"
       end
 
       def email_path
-        'activity/email/'
+        "#{activity_path}email/"
       end
 
       def emailthread_path
-        'activity/emailthread/'
+        "#{activity_path}emailthread/"
       end
 
       def call_path
-        'activity/call/'
+        "#{activity_path}call/"
       end
 
       def sms_path
-        'activity/sms/'
+        "#{activity_path}sms/"
       end
     end
   end

--- a/lib/closeio/resources/activity.rb
+++ b/lib/closeio/resources/activity.rb
@@ -85,6 +85,30 @@ module Closeio
         delete("#{call_path}#{id}/")
       end
 
+      #
+      #  SMS Activities
+      #
+
+      def list_sms(options = {})
+        get(sms_path, options)
+      end
+
+      def find_sms(id)
+        get("#{sms_path}#{id}/")
+      end
+
+      def create_sms
+        post(sms_path, options)
+      end
+
+      def update_sms
+        put("#{sms_path}#{id}/", options)
+      end
+
+      def delete_sms(id)
+        delete("#{sms_path}#{id}/")
+      end
+
       private
 
       def activity_path
@@ -105,6 +129,10 @@ module Closeio
 
       def call_path
         'activity/call/'
+      end
+
+      def sms_path
+        'activity/sms/'
       end
     end
   end

--- a/lib/closeio/version.rb
+++ b/lib/closeio/version.rb
@@ -1,3 +1,3 @@
 module Closeio
-  VERSION = '3.5.1'.freeze
+  VERSION = '3.6.0'.freeze
 end


### PR DESCRIPTION
Adding the following methods to `Closeio::Client::Activity`:
- `list_sms`
- `find_sms`
- `create_sms`
- `update_sms`
- `delete_sms`

and bumping version to 3.6.0