### PR TITLE
Fix: add missing parameters in method definitions and update version to 3.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.6.0
+## 3.6.1
 
 - Add support for SMS activities
 

--- a/lib/closeio/resources/activity.rb
+++ b/lib/closeio/resources/activity.rb
@@ -97,11 +97,11 @@ module Closeio
         get("#{sms_path}#{id}/")
       end
 
-      def create_sms
+      def create_sms(options)
         post(sms_path, options)
       end
 
-      def update_sms
+      def update_sms(id, options = {})
         put("#{sms_path}#{id}/", options)
       end
 

--- a/lib/closeio/version.rb
+++ b/lib/closeio/version.rb
@@ -1,3 +1,3 @@
 module Closeio
-  VERSION = '3.6.0'.freeze
+  VERSION = '3.6.1'.freeze
 end


### PR DESCRIPTION
Sorry @taylorbrooks. I realized I went too fast and had forgotten parameters in the definitions of `create_sms` and `update_sms`. This PR fixes it.