### PR TITLE
Use quotation symbols for query params

### DIFF
--- a/lib/closeio/client.rb
+++ b/lib/closeio/client.rb
@@ -76,7 +76,7 @@ module Closeio
 
     def assemble_list_query(query, options)
       options[:query] = if query.respond_to? :map
-                          query.map { |k, v| "#{k}:'#{v}'" }.join(' ')
+                          query.map { |k, v| "#{k}:\"#{v}\"" }.join(' ')
                         else
                           query
                         end


### PR DESCRIPTION
Need to use quotation symbols for query params.
Using apostrophe symbols makes results unpredictable.
For example, when searching for leads by name.
This fix was suggested by Close tech support.