### PR TITLE
[#66] Fix faraday basic_auth warning in connection

### DIFF
--- a/lib/closeio/client.rb
+++ b/lib/closeio/client.rb
@@ -94,7 +94,7 @@ module Closeio
         },
         ssl: { ca_file: ca_file }
       ) do |conn|
-        conn.basic_auth api_key, ''
+        conn.request    :basic_auth, api_key, ''
         conn.request    :json
         conn.response   :logger if logger
         conn.response   :json


### PR DESCRIPTION
Fix Faraday basic auth deprecation

```
WARNING: `Faraday::Connection#basic_auth` is deprecated; it will be removed in version 2.0.
While initializing your connection, use `#request(:basic_auth, ...)` instead.
See https://lostisland.github.io/faraday/middleware/authentication for more usage info.
```