### PR TITLE
Added the ability to update a call

### DIFF
--- a/lib/closeio/resources/activity.rb
+++ b/lib/closeio/resources/activity.rb
@@ -85,6 +85,10 @@ module Closeio
         post(call_path, options)
       end
 
+      def update_call(id, options = {})
+        put("#{call_path}#{id}/", options)
+      end
+
       def delete_call(id)
         delete("#{call_path}#{id}/")
       end


### PR DESCRIPTION
Method was missing to update a call per Close docs:

[https://developer.close.com/resources/activities/call/#update-a-call-activity](https://developer.close.com/resources/activities/call/#update-a-call-activity)

Just added the method using the existing path setup

@taylorbrooks 