### PR TITLE
feat: Simple addition of querying the advanced filter endpoint

### DIFF
--- a/lib/closeio/client.rb
+++ b/lib/closeio/client.rb
@@ -8,6 +8,7 @@ Dir[File.expand_path('../resources/*.rb', __FILE__)].each { |f| require f }
 module Closeio
   class Client
     include Closeio::Client::Activity
+    include Closeio::Client::AdvancedFilter
     include Closeio::Client::BulkAction
     include Closeio::Client::Contact
     include Closeio::Client::CustomActivity

--- a/lib/closeio/resources/advanced_filter.rb
+++ b/lib/closeio/resources/advanced_filter.rb
@@ -1,0 +1,16 @@
+module Closeio
+  class Client
+    module AdvancedFilter
+      def advanced_filter(query)
+        post(advanced_filter_path, query)
+      end
+
+      private
+
+      def advanced_filter_path
+        'data/search/'
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
Simple call `client.advanced_filter(QUERYBODY={})` to run a query against the advanced filters endpoint